### PR TITLE
add development mode auto to template

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -28,6 +28,9 @@ template:
     btn-border-radius: 0.25rem
     link-decoration: "none"
 
+development:
+  mode: auto
+
 navbar:
   structure:
     left:


### PR DESCRIPTION
This will ensure the documentation stays in sync with the released version and that the in-development documentation will be presented under `/dev/` (see for example https://usethis.r-lib.org/dev/news/index.html)

